### PR TITLE
use fetch API and return promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ a bridge-generated username (we omit error callbacks below):
 var bridge = hue.bridge('192.168.1.2');
 
 // create user account (requires link button to be pressed)
-bridge.createUser('foo application', function(data) {
+bridge.createUser('foo application').then( data => {
     // extract bridge-generated username from returned data
     var username = data[0].success.username;
 
@@ -79,7 +79,7 @@ bridge.createUser('foo application', function(data) {
 Once authenticated, you can do anything with the API, like turn on a light:
 
 ```js
-user.setLightState(1, { on: true }, function(data) { /* ... */ });
+user.setLightState(1, { on: true }).then( data => { /* ... */ });
 ```
 
 For more details, see the source code. jsHue's object interface maps directy to

--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ Once authenticated, you can do anything with the API, like turn on a light:
 user.setLightState(1, { on: true }).then( data => { /* ... */ })
 ```
 
-For more details, see the source code. jsHue's object interface maps direclty to the API, so it is very straightforward to use.
+For more details, see the source code. jsHue's object interface maps directly to the API, so it is very straightforward to use.
 
-# Contributors
+## Contributors

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 A simple JavaScript library for Philips Hue.
 
-Version 1.0.0
+Version 0.3.0
 
-Copyright (c) 2015 John Peloquin (original code). All rights reserved.
-Copyright (c) 2017 Tom Brewe (fetch and Promise API changes)
+Copyright 2013 - 2017, John Peloquin and the jsHue contributors.
 
 ## Introduction
 
@@ -37,7 +36,6 @@ Then you can discover local bridges:
 
 ```js
 hue.discover().then(bridges => {
-    
     if(bridges.length === 0) {
         console.log('No bridges found. :(');
     }
@@ -46,12 +44,10 @@ hue.discover().then(bridges => {
             console.log('Bridge found at IP address %s.', b.internalipaddress);
         });
     }
-    
-}
-).catch((err) => {console.log('Error finding bridges', err)});
+}).catch((e) => {console.log('Error finding bridges', e)});
 ```
 
-jsHue-promise performs requests asynchronously and provides a Promise interface. You can `catch` errors as usual, like in the example below.
+jsHue performs requests asynchronously and provides a Promise interface. Each promise results in Hue API success and error objects. Additionally, you can `catch` request and JSON serialization/deserialization errors at the end of the promise chain.
 
 Once you have a local bridge IP address, you can create a user on the bridge with a bridge-generated username (we omit error callbacks below):
 
@@ -73,7 +69,9 @@ bridge.createUser('myApp#testdevice').then(data => {
 Once authenticated, you can do anything with the API, like turn on a light:
 
 ```js
-user.setLightState(1, { on: true }).then( data => { /* ... */ });
+user.setLightState(1, { on: true }).then( data => { /* ... */ })
 ```
 
 For more details, see the source code. jsHue's object interface maps direclty to the API, so it is very straightforward to use.
+
+# Contributors

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 A simple JavaScript library for Philips Hue.
 
-Version 0.3.0.
+Version 1.0.0
 
-Copyright (c) 2015 John Peloquin. All rights reserved.
+Copyright (c) 2015 John Peloquin (original code). All rights reserved.
+Copyright (c) 2017 Tom Brewe (fetch and Promise API changes)
 
 ## Introduction
 
@@ -35,37 +36,30 @@ var hue = jsHue();
 Then you can discover local bridges:
 
 ```js
-hue.discover(
-    function(bridges) {
-        if(bridges.length === 0) {
-            console.log('No bridges found. :(');
-        }
-        else {
-            bridges.forEach(function(b) {
-                console.log('Bridge found at IP address %s.', b.internalipaddress);
-            });
-        }
-    },
-    function(error) {
-        console.error(error.message);
+hue.discover().then(bridges => {
+    
+    if(bridges.length === 0) {
+        console.log('No bridges found. :(');
     }
-);
+    else {
+        bridges.forEach(function(b) {
+            console.log('Bridge found at IP address %s.', b.internalipaddress);
+        });
+    }
+    
+}
+).catch((err) => {console.log('Error finding bridges', err)});
 ```
 
-jsHue performs requests asynchronously and provides a callback interface. The
-failure callback is called if the XHR request fails, or if there is an error with
-the JSON serialization or deserialization. All API success and error results are
-returned in the success callback data. (This is because some API calls may return
-aggregated API success and error results.)
+jsHue-promise performs requests asynchronously and provides a Promise interface. You can `catch` errors as usual, like in the example below.
 
-Once you have a local bridge IP address, you can create a user on the bridge with
-a bridge-generated username (we omit error callbacks below):
+Once you have a local bridge IP address, you can create a user on the bridge with a bridge-generated username (we omit error callbacks below):
 
 ```js
 var bridge = hue.bridge('192.168.1.2');
 
 // create user account (requires link button to be pressed)
-bridge.createUser('foo application').then( data => {
+bridge.createUser('myApp#testdevice').then(data => {
     // extract bridge-generated username from returned data
     var username = data[0].success.username;
 
@@ -82,5 +76,4 @@ Once authenticated, you can do anything with the API, like turn on a light:
 user.setLightState(1, { on: true }).then( data => { /* ... */ });
 ```
 
-For more details, see the source code. jsHue's object interface maps directy to
-the API, so it is very straightforward to use.
+For more details, see the source code. jsHue's object interface maps direclty to the API, so it is very straightforward to use.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple JavaScript library for Philips Hue.
 
-Version 0.3.0
+Version 1.0.0
 
 Copyright 2013 - 2017, John Peloquin and the jsHue contributors.
 

--- a/src/jshue.js
+++ b/src/jshue.js
@@ -2,8 +2,8 @@
  * jsHue
  * JavaScript library for Philips Hue.
  *
- * @module jshue
- * @version 0.3.0
+ * @module jshue-next
+ * @version 1.0.0
  * @author John Peloquin
  * @copyright Copyright (c) 2013 John Peloquin. All rights reserved.
  * @copyright Copyright (c) 2017 Tom Brewe (fetch API and promise changes)

--- a/src/jshue.js
+++ b/src/jshue.js
@@ -2,11 +2,10 @@
  * jsHue
  * JavaScript library for Philips Hue.
  *
- * @module jshue-next
+ * @module jshue
  * @version 1.0.0
  * @author John Peloquin
- * @copyright Copyright (c) 2013 John Peloquin. All rights reserved.
- * @copyright Copyright (c) 2017 Tom Brewe (fetch API and promise changes)
+ * Copyright 2013 - 2017, John Peloquin and the jsHue contributors.
  */
 
 /**
@@ -43,15 +42,17 @@ var jsHueAPI = function(fetch, JSON) {
      * @param {String} method GET, PUT, POST, or DELETE
      * @param {String} url request URL
      * @param {Object} data request data object to serialize for request JSON
-     * @return {Boolean} true if request was sent, false otherwise
+     * @return {Promise} resolving to JSON response
      */
     var _requestJson = function(method, url, data) {
-        if(data !== null) {
-            data = JSON.stringify(data);
-        }
-        
-        return fetch(url, {method: method, body: data}).then(blob => blob.json());
-        
+        return new Promise(resolve => {
+            if(data !== null) {
+                data = JSON.stringify(data);
+            }
+            resolve(data);
+         })
+         .then(data => fetch(url, {method: method, body: data}))
+         .then(response => response.json());
     };
 
     /**
@@ -61,10 +62,10 @@ var jsHueAPI = function(fetch, JSON) {
      * @private
      * @param {String} method GET, PUT, POST, or DELETE
      * @param {String} url request URL
-     * @return {Boolean} true if request was sent, false otherwise
+     * @return {Promise}
      */
     var _requestJsonUrl = function(method, url) {
-        return _requestJson(method, url);
+        return _requestJson(method, url, null);
     };
 
     /**
@@ -73,7 +74,7 @@ var jsHueAPI = function(fetch, JSON) {
      * @method _get
      * @private
      * @param {String} url request URL
-     * @return {Boolean} true if request was sent, false otherwise
+     * @return {Promise}
      */
     var _get = _requestJsonUrl.bind(null, 'GET');
 
@@ -84,7 +85,7 @@ var jsHueAPI = function(fetch, JSON) {
      * @private
      * @param {String} url request URL
      * @param {Object} data request data object
-     * @return {Boolean} true if request was sent, false otherwise
+     * @return {Promise}
      */
     var _put = _requestJson.bind(null, 'PUT');
 
@@ -95,7 +96,7 @@ var jsHueAPI = function(fetch, JSON) {
      * @private
      * @param {String} url request URL
      * @param {Object} data request data object
-     * @return {Boolean} true if request was sent, false otherwise
+     * @return {Promise}
      */
     var _post = _requestJson.bind(null, 'POST');
 
@@ -105,7 +106,7 @@ var jsHueAPI = function(fetch, JSON) {
      * @method _delete
      * @private
      * @param {String} url request URL
-     * @return {Boolean} true if request was sent, false otherwise
+     * @return {Promise}
      */
     var _delete = _requestJsonUrl.bind(null, 'DELETE');
 

--- a/src/jshue.js
+++ b/src/jshue.js
@@ -46,12 +46,11 @@ var jsHueAPI = function(fetch, JSON) {
      * @return {Boolean} true if request was sent, false otherwise
      */
     var _requestJson = function(method, url, data) {
-
         if(data !== null) {
             data = JSON.stringify(data);
         }
-
-        return fetch(url, {method, data}).then(blob => blob.json());
+        
+        return fetch(url, {method: method, body: data}).then(blob => blob.json());
         
     };
 

--- a/src/jshue.js
+++ b/src/jshue.js
@@ -6,6 +6,7 @@
  * @version 0.3.0
  * @author John Peloquin
  * @copyright Copyright (c) 2013 John Peloquin. All rights reserved.
+ * @copyright Copyright (c) 2017 Tom Brewe (fetch API and promise changes)
  */
 
 /**
@@ -18,22 +19,6 @@
  * @return {Object} instance
  */
 var jsHueAPI = function(fetch, JSON) {
-    /**
-     * Substitutes strings for URLs.
-     *
-     * Example: _sub('http://{host}/bar', { host: 'foo' }) returns 'http://foo/bar'.
-     *
-     * @method _sub
-     * @private
-     * @param {String} str input string
-     * @param {Object} data key/value substitutions
-     * @return {String} output string
-     */
-    var _sub = function(str, data) {
-        return str.replace(/\{(\w+)\}/g, function(t, k) {
-            return data[k] || t;
-        });
-    };
 
     /**
      * Concatenates strings for URLs.
@@ -181,7 +166,7 @@ var jsHueAPI = function(fetch, JSON) {
             /**
              * @class jsHueBridge
              */
-            var _bridgeUrl = _sub('http://{ip}/api', { ip: ip });
+            var _bridgeUrl = `http://${ip}/api`;
             return {
                 /**
                  * Creates new user in bridge whitelist.


### PR DESCRIPTION
Hey there,
Great library! The direct mapping makes it very robust. However I find myself increasingly working with the relatively new [Promise API](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Promise). Thats why I transformed the relevant parts of the code in jshue to use the newer `fetch` API instead of `XMLHttpRequest`, which enables the return of promises. (See new Readme for example usage).

The fail/success callbacks have been removed, because errors can now simply be `catch`ed at the end of the promise.

I can understand if you prefer not not merge it, because of incompatibilities with older browsers or because you prefer the callback syntax.
Basically, I still wanted to give you a heads up that I did this fork and give you the option to merge this change if you like. Otherwise I'll publish the fork to npm under the name `jshue` for easy installation, unless you'd prefer that I use a different name for npm like `jshue-next` for better distinction. Just let me know.

Credit to your original project and the MIT licence remains of course.