### PR TITLE
add conditional module.exports for initial module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple JavaScript library for Philips Hue.
 
-Version 2.0.0
+Version 2.0.1
 
 Copyright 2013 - 2017, John Peloquin and the jsHue contributors.
 
@@ -43,21 +43,34 @@ var hue = jsHue();
 ```
 
 
-Alternatively, if you use yarn or npm with a bundler like webpack or rollup (note: jshue is supposed to be used in a browser context):
-<details>
-<summary>npm install --save jshue</summary>
 
-```.js
+<details>
+<summary>Alternatively, you can use a package manager like [yarn](https://yarnpkg.com/lang/en/) or [npm](http://npmjs.com/) (click arrow to show details)</summary>
+
+```.sh
 npm install --save jshue //or: yarn add jshue
 ```
 
 then:
+
 ```js
-jsHue = require('jsHue'); // or: import jsHue from 'jsHue';
+import jsHue from 'jsHue';
 var hue = jsHue();
 ```
+
+or:
+
+```.js
+let jsHue = require('jsHue');
+var hue = jsHue();
+```
+
+Note: jshue is supposed to be used in a browser context, therefore you need a bundler like webpack, rollup or browserify when
+requiring or importing the module as in the above example.
+
 </details>
 
+---------------------------------
 
 Then you can discover local bridges:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var hue = jsHue();
 
 
 <details>
-<summary>Alternatively, you can use a package manager like [yarn](https://yarnpkg.com/lang/en/) or [npm](http://npmjs.com/) (click arrow to show details)</summary>
+<summary>Alternatively, you can use a package manager like yarn or npm (click arrow to show details)</summary>
 
 ```.sh
 npm install --save jshue //or: yarn add jshue

--- a/README.md
+++ b/README.md
@@ -30,11 +30,34 @@ an older environment, consider v0.3.0.)
 
 ## Getting Started
 
-To get started, instantiate jsHue:
 
+[Download jshue](https://github.com/nylki/jshue/releases) and include it in your html:
+
+```js
+<script src="path/to/jshue.js"></script>
+```
+
+then instantiate jsHue in your code:
 ```js
 var hue = jsHue();
 ```
+
+
+Alternatively, if you use yarn or npm with a bundler like webpack or rollup (note: jshue is supposed to be used in a browser context):
+<details>
+<summary>npm install --save jshue</summary>
+
+```.js
+npm install --save jshue //or: yarn add jshue
+```
+
+then:
+```js
+jsHue = require('jsHue'); // or: import jsHue from 'jsHue';
+var hue = jsHue();
+```
+</details>
+
 
 Then you can discover local bridges:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jshue",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A simple JavaScript library for Philips Hue",
   "main": "src/jshue.js",
   "repository": {

--- a/src/jshue.js
+++ b/src/jshue.js
@@ -674,4 +674,8 @@ if(typeof fetch !== 'undefined' && typeof Response !== 'undefined'
      * @return {Object} instance
      */
     var jsHue = jsHueAPI.bind(null, fetch, Response, JSON, Promise);
+    // Try to export to be used via require in NodeJS.
+    if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+	    module.exports = jsHue;
+    }
 }

--- a/src/jshue.js
+++ b/src/jshue.js
@@ -3,7 +3,7 @@
  * JavaScript library for Philips Hue.
  *
  * @module jshue
- * @version 2.0.0
+ * @version 2.0.1
  * @author John Peloquin
  * @copyright Copyright 2013 - 2017, John Peloquin and the jsHue contributors.
  */
@@ -674,7 +674,7 @@ if(typeof fetch !== 'undefined' && typeof Response !== 'undefined'
      * @return {Object} instance
      */
     var jsHue = jsHueAPI.bind(null, fetch, Response, JSON, Promise);
-    // Try to export to be used via require in NodeJS.
+    // Try to export to be used as a module via a bundler
     if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
 	    module.exports = jsHue;
     }


### PR DESCRIPTION
This code change allows to export jshue as a module if it is possible. There is no change for the browser context, as `module` does not exist there. This conditional `module.exports` is used in several other libraries to support require/module syntax as well.

The change allows bundlers like `rollup`, `webpack` or `browserify` to include `jshue` in the following way: 

```.js
var jsHue = require('jsHue'); // or var jsHue = require('path/to/jsHue.js')
var hue = jsHue();
```
and also with the import statement if the bundler supports it:
```.js
import jsHue from 'jsHue'; // or import jsHue from 'path/to/jsHue.js';
var hue = jsHue();
```

I tested both in my own code with success.
Should you merge this, please also publish the new version via npm, so it can be used as the Readme says :)
